### PR TITLE
Improve pulse animation with restart and BPM-based speed

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ interface BPMState {
   buttonPresses: number[]
   currentBPM: number
   timeoutId: number | null
+  pulseTimeoutId: number | null
 }
 
 const state: BPMState = {
@@ -14,7 +15,8 @@ const state: BPMState = {
   startTime: null,
   buttonPresses: [],
   currentBPM: 0,
-  timeoutId: null
+  timeoutId: null,
+  pulseTimeoutId: null
 }
 
 // Get the app element
@@ -60,6 +62,12 @@ function handleButtonPress(bpmValueElement: HTMLElement) {
   
   // Force restart pulse animation effect
   if (button) {
+    // Clear any existing pulse timeout
+    if (state.pulseTimeoutId) {
+      clearTimeout(state.pulseTimeoutId)
+      state.pulseTimeoutId = null
+    }
+    
     // Remove the class first to restart animation if it's already playing
     button.classList.remove('pulse')
     
@@ -73,8 +81,9 @@ function handleButtonPress(bpmValueElement: HTMLElement) {
     button.classList.add('pulse')
     
     // Remove the class after the animation completes
-    setTimeout(() => {
+    state.pulseTimeoutId = setTimeout(() => {
       button.classList.remove('pulse')
+      state.pulseTimeoutId = null
     }, animationDuration * 1000)
   }
   
@@ -160,6 +169,12 @@ function stopMeasuring(bpmValueElement: HTMLElement) {
   state.buttonPresses = []
   state.currentBPM = 0
   state.timeoutId = null
+  
+  // Clear pulse timeout if active
+  if (state.pulseTimeoutId) {
+    clearTimeout(state.pulseTimeoutId)
+    state.pulseTimeoutId = null
+  }
   
   bpmValueElement.textContent = '--'
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,12 +52,30 @@ function handleButtonPress(bpmValueElement: HTMLElement) {
   const now = Date.now()
   const button = document.getElementById('bpm-button')
   
-  // Add pulse animation effect
+  // Calculate animation duration based on BPM (max 60/BPM seconds, min 0.3s, max 2s)
+  let animationDuration = 0.6 // Default 0.6s
+  if (state.currentBPM > 0) {
+    animationDuration = Math.min(Math.max(60 / state.currentBPM, 0.3), 2)
+  }
+  
+  // Force restart pulse animation effect
   if (button) {
+    // Remove the class first to restart animation if it's already playing
+    button.classList.remove('pulse')
+    
+    // Set the animation duration as CSS custom property
+    button.style.setProperty('--pulse-duration', `${animationDuration}s`)
+    
+    // Force a reflow to ensure the class removal takes effect
+    button.offsetHeight
+    
+    // Add the pulse class to start the animation
     button.classList.add('pulse')
+    
+    // Remove the class after the animation completes
     setTimeout(() => {
       button.classList.remove('pulse')
-    }, 600)
+    }, animationDuration * 1000)
   }
   
   // Vibrate on mobile devices (very brief)

--- a/src/style.css
+++ b/src/style.css
@@ -125,7 +125,7 @@ p {
 
 /* Pulse animation */
 .heart-button.pulse {
-  animation: pulse-animation 0.6s ease-out;
+  animation: pulse-animation var(--pulse-duration, 0.6s) ease-out;
 }
 
 @keyframes pulse-animation {
@@ -155,7 +155,7 @@ p {
   border: 3px solid var(--secondary-main);
   border-radius: 50%;
   opacity: 0;
-  animation: pulse-ring 0.6s ease-out;
+  animation: pulse-ring var(--pulse-duration, 0.6s) ease-out;
   z-index: 1;
 }
 


### PR DESCRIPTION
This PR implements the improvements requested in issue #14:

## Changes
- **Fixed animation restart**: Remove pulse class before adding it to force restart when button is pressed during animation
- **Added BPM-based speed adjustment**: Animation duration now adapts based on current BPM (duration = min(max(60/BPM, 0.3), 2) seconds)
- **Enhanced reliability**: Force browser reflow to ensure animation restart works consistently
- **Dynamic timing**: Use CSS custom properties for runtime animation duration control

The animation now:
1. Always restarts when the user presses the button, providing consistent visual feedback
2. Adjusts speed according to the current BPM (faster for higher BPM, slower for lower BPM)
3. Maintains reasonable bounds (300ms minimum, 2s maximum) for good UX

Fixes #14

Generated with [Claude Code](https://claude.ai/code)