### PR TITLE
feat: make heart button responsively sized for mobile

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -65,13 +65,13 @@ p {
 /* Heart-shaped button */
 .heart-button {
   display: block;
-  width: 200px;
-  height: 180px;
+  width: min(200px, 80vw);
+  height: min(180px, 72vw);
   margin: 0 auto 2rem;
   border: none;
   background: transparent;
   color: var(--light-highlight);
-  font-size: 1.5rem;
+  font-size: clamp(1rem, 4vw, 1.5rem);
   font-weight: 600;
   line-height: 1.4;
   cursor: pointer;
@@ -205,18 +205,32 @@ p {
     font-size: 2.5rem;
   }
   
-  .heart-button {
-    width: 160px;
-    height: 144px;
-    font-size: 1rem;
-  }
-  
   .bpm-display {
     font-size: 2rem;
   }
   
   .bpm-display label {
     font-size: 1.5rem;
+  }
+}
+
+/* Extra small screens */
+@media (max-width: 320px) {
+  .container {
+    margin: 0.5rem;
+    padding: 1rem;
+  }
+  
+  h1 {
+    font-size: 2rem;
+  }
+  
+  .bpm-display {
+    font-size: 1.5rem;
+  }
+  
+  .bpm-display label {
+    font-size: 1.2rem;
   }
 }
 


### PR DESCRIPTION
Implements responsive sizing for the heart button to prevent overflow on mobile devices.

## Changes
- Replace fixed pixel dimensions with responsive viewport units
- Width: `min(200px, 80vw)` to prevent overflow on narrow screens
- Height: `min(180px, 72vw)` to maintain aspect ratio
- Font size: `clamp(1rem, 4vw, 1.5rem)` for smooth scaling
- Add 320px breakpoint for extra small screens

## Behavior
The button now automatically shrinks when the screen size is smaller than the button size, keeping it centered and preventing off-screen overflow.

Fixes #16

🤖 Generated with [Claude Code](https://claude.ai/code)